### PR TITLE
Updated rnadeseq notes

### DIFF
--- a/docs/markdown/pipelines/pipeline_releases.md
+++ b/docs/markdown/pipelines/pipeline_releases.md
@@ -9,7 +9,7 @@ These versions will be revised periodically and tested in our infrastructure bef
 | Analysis type         | Pipeline                                                                  | Use version |
 | --------------------- | ------------------------------------------------------------------------- | :---------: |
 | RNAseq                | [nf-core/rnaseq](https://nf-co.re/rnaseq/1.4.2)                           |    1.4.2    |
-| RNAseq DE analysis    | [qbic-pipelines/rnadeseq](https://github.com/qbic-pipelines/rnadeseq)     |    2.1      |
+| RNAseq DE analysis    | [qbic-pipelines/rnadeseq](https://github.com/qbic-pipelines/rnadeseq)     |     2.1     |
 | WGS / WES             | [nf-core/sarek](https://nf-co.re/sarek/2.7.1)                             |    2.7.1    |
 | HLAtyping             | [nf-core/hlatyping](https://nf-co.re/hlatyping/1.2.0)                     |    1.2.0    |
 | 16S amplicon          | [nf-core/ampliseq](https://nf-co.re/ampliseq/2.1.1)                       |    2.1.1    |

--- a/docs/markdown/pipelines/pipeline_releases.md
+++ b/docs/markdown/pipelines/pipeline_releases.md
@@ -9,7 +9,7 @@ These versions will be revised periodically and tested in our infrastructure bef
 | Analysis type         | Pipeline                                                                  | Use version |
 | --------------------- | ------------------------------------------------------------------------- | :---------: |
 | RNAseq                | [nf-core/rnaseq](https://nf-co.re/rnaseq/1.4.2)                           |    1.4.2    |
-| RNAseq DE analysis    | [qbic-pipelines/rnadeseq](https://github.com/qbic-pipelines/rnadeseq)     |    1.3.2    |
+| RNAseq DE analysis    | [qbic-pipelines/rnadeseq](https://github.com/qbic-pipelines/rnadeseq)     |    2.1      |
 | WGS / WES             | [nf-core/sarek](https://nf-co.re/sarek/2.7.1)                             |    2.7.1    |
 | HLAtyping             | [nf-core/hlatyping](https://nf-co.re/hlatyping/1.2.0)                     |    1.2.0    |
 | 16S amplicon          | [nf-core/ampliseq](https://nf-co.re/ampliseq/2.1.1)                       |    2.1.1    |

--- a/docs/markdown/pipelines/pipeline_releases.md
+++ b/docs/markdown/pipelines/pipeline_releases.md
@@ -9,7 +9,7 @@ These versions will be revised periodically and tested in our infrastructure bef
 | Analysis type         | Pipeline                                                                  | Use version |
 | --------------------- | ------------------------------------------------------------------------- | :---------: |
 | RNAseq                | [nf-core/rnaseq](https://nf-co.re/rnaseq/1.4.2)                           |    1.4.2    |
-| RNAseq DE analysis    | [qbic-pipelines/rnadeseq](https://github.com/qbic-pipelines/rnadeseq)     |    2.1    |
+| RNAseq DE analysis    | [qbic-pipelines/rnadeseq](https://github.com/qbic-pipelines/rnadeseq)     |     2.1     |
 | WGS / WES             | [nf-core/sarek](https://nf-co.re/sarek/3.1.2)                             |    3.1.2    |
 | HLAtyping             | [nf-core/hlatyping](https://nf-co.re/hlatyping/1.2.0)                     |    1.2.0    |
 | 16S amplicon          | [nf-core/ampliseq](https://nf-co.re/ampliseq/2.1.1)                       |    2.1.1    |

--- a/docs/markdown/pipelines/rnaseq.md
+++ b/docs/markdown/pipelines/rnaseq.md
@@ -61,6 +61,7 @@ If you want to run a version <2.1, the container.config has to look like this:
 ```bash
 process.container = 'ghcr.io/qbic-pipelines/rnadeseq:1.1.0'
 ```
+
 The container link has to be adjusted to the version you want to run. You should just have to change the version number, but you can double-check on https://github.com/qbic-pipelines/rnadeseq/pkgs/container/rnadeseq if you are not sure if the link is correct.
 
 Then, call this container.config when running the pipeline, like so:

--- a/docs/markdown/pipelines/rnaseq.md
+++ b/docs/markdown/pipelines/rnaseq.md
@@ -31,17 +31,15 @@ Example command (change `cfc` for `binac` on binac cluster):
 
 ```bash
 #!/usr/bin/bash
-nextflow run qbicsoftware/rnadeseq -r 1.3.2 -profile docker \
---rawcounts 'merged_gene_counts.txt' \
---metadata 'QXXXX_sample_preparations.tsv' \
+nextflow run qbicsoftware/rnadeseq -r 2.1 -profile docker \
+--gene_counts 'merged_gene_counts.txt' \
+--input 'QXXXX_sample_preparations.tsv' \
 --model 'linear_model.txt' \
 --contrast_matrix 'contrasts.tsv' \
 --project_summary 'QXXXX_summary.tsv' \
 --multiqc 'MultiQC.zip' \
---quote 'QXXXX_signed_offer.pdf' \
---versions 'software_versions.csv' \
---report_options 'report_options.yml' \
---species Hsapiens
+--software_versions 'software_versions.csv' \
+--genome 'GRCh37'
 ```
 
 ### Known issues


### PR DESCRIPTION
Updated version and install command for rnadeseq
Edit 21.4.23: Also added explanation about using older rnadeseq pipeline versions with the respective ghcr container