### PR TITLE
Update ampliseq docs to 2.4.1

### DIFF
--- a/docs/markdown/pipelines/ampliseq.md
+++ b/docs/markdown/pipelines/ampliseq.md
@@ -8,12 +8,12 @@ To perform 16S amplicon sequencing analyses we employ the [nf-core/ampliseq](htt
 
 ### Quick start
 
-- Latest stable release `-r 2.1.1`
+- Latest stable release `-r 2.4.1`
 
 A typical command would look like this
 
 ```bash
-nextflow run nf-core/ampliseq -profile cfc -r 2.1.1 \
+nextflow run nf-core/ampliseq -profile cfc -r 2.4.1 \
 --input “data” \
 --FW_primer "GTGYCAGCMGCCGCGGTAA" \
 --RV_primer "GGACTACNVGGGTWTCTAAT" \
@@ -21,12 +21,12 @@ nextflow run nf-core/ampliseq -profile cfc -r 2.1.1 \
 --trunc_qmin 35
 ```
 
-Sequencing data can be analysed with the pipeline using a folder containing `.fastq.gz` files with [direct fastq input](https://nf-co.re/ampliseq/2.1.1/usage#direct-fastq-input) or [samplesheet input](https://nf-co.re/ampliseq/2.1.1/usage#samplesheet-input), also see [here](https://nf-co.re/ampliseq/2.1.1/parameters#input).
+Sequencing data can be analysed with the pipeline using a folder containing `.fastq.gz` files with [direct fastq input](https://nf-co.re/ampliseq/2.4.1/usage#direct-fastq-input) or [samplesheet input](https://nf-co.re/ampliseq/2.4.1/usage#samplesheet-input), also see [here](https://nf-co.re/ampliseq/2.4.1/parameters#input).
 
-See [here](https://nf-co.re/ampliseq/2.1.1/parameters#metadata) the info on how to create the `metadata.tsv` file.
+See [here](https://nf-co.re/ampliseq/2.4.1/parameters#metadata) the info on how to create the `metadata.tsv` file.
 
-If data are distributed on multiple sequencing runs, please use `--multipleSequencingRuns` and note the different requirements for metadata file and folder structure in the [pipeline documentation](https://nf-co.re/ampliseq/1.2.0/parameters#multiplesequencingruns)
+If data are distributed on multiple sequencing runs, please use `--multipleSequencingRuns` and note the different requirements for metadata file and folder structure in the [pipeline documentation](https://nf-co.re/ampliseq/2.4.1/parameters#multiple_sequencing_runs)
 
 ## Reporting
 
-There are no details about reporting yet. Please refer to the [output documentation](https://nf-co.re/ampliseq/2.1.1/output).
+There are no details about reporting yet. Please refer to the [output documentation](https://nf-co.re/ampliseq/2.4.1/output).


### PR DESCRIPTION
Updated the docs for 2.4.1.
Not much changed except links.
Sorry for using the github GUI and leaving a branch here.